### PR TITLE
.Net Core version of amazon-kinesis-client-net

### DIFF
--- a/AWS_KCL_DotNet.sln
+++ b/AWS_KCL_DotNet.sln
@@ -1,15 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2027
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Amazon.Kinesis.ClientLibrary", "Amazon.Kinesis.ClientLibrary", "{6A5832F9-5282-4942-AB13-0F1D4D391BB2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bootstrap", "Bootstrap\Bootstrap.csproj", "{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bootstrap", "Bootstrap\Bootstrap.csproj", "{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClientLibrary", "ClientLibrary\ClientLibrary.csproj", "{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClientLibrary", "ClientLibrary\ClientLibrary.csproj", "{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleProducer", "SampleProducer\SampleProducer.csproj", "{72E5E459-5045-4785-BD53-FE93EF10ECF7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleConsumer", "SampleConsumer\SampleConsumer.csproj", "{83F76D79-CA64-45D6-978B-AB6528F1D4F1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleConsumer", "SampleConsumer\SampleConsumer.csproj", "{83F76D79-CA64-45D6-978B-AB6528F1D4F1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,27 +19,33 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}.Debug|x86.ActiveCfg = Debug|x86
-		{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}.Debug|x86.Build.0 = Debug|x86
-		{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}.Release|x86.ActiveCfg = Release|x86
-		{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}.Release|x86.Build.0 = Release|x86
-		{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}.Debug|x86.ActiveCfg = Debug|x86
-		{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}.Debug|x86.Build.0 = Debug|x86
-		{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}.Release|x86.ActiveCfg = Release|x86
-		{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}.Release|x86.Build.0 = Release|x86
-		{72E5E459-5045-4785-BD53-FE93EF10ECF7}.Debug|x86.ActiveCfg = Debug|x86
-		{72E5E459-5045-4785-BD53-FE93EF10ECF7}.Debug|x86.Build.0 = Debug|x86
-		{72E5E459-5045-4785-BD53-FE93EF10ECF7}.Release|x86.ActiveCfg = Release|x86
-		{72E5E459-5045-4785-BD53-FE93EF10ECF7}.Release|x86.Build.0 = Release|x86
-		{83F76D79-CA64-45D6-978B-AB6528F1D4F1}.Debug|x86.ActiveCfg = Debug|x86
-		{83F76D79-CA64-45D6-978B-AB6528F1D4F1}.Debug|x86.Build.0 = Debug|x86
-		{83F76D79-CA64-45D6-978B-AB6528F1D4F1}.Release|x86.ActiveCfg = Release|x86
-		{83F76D79-CA64-45D6-978B-AB6528F1D4F1}.Release|x86.Build.0 = Release|x86
+		{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}.Debug|x86.Build.0 = Debug|Any CPU
+		{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}.Release|x86.Build.0 = Release|Any CPU
+		{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}.Debug|x86.Build.0 = Debug|Any CPU
+		{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}.Release|x86.ActiveCfg = Release|Any CPU
+		{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}.Release|x86.Build.0 = Release|Any CPU
+		{72E5E459-5045-4785-BD53-FE93EF10ECF7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{72E5E459-5045-4785-BD53-FE93EF10ECF7}.Debug|x86.Build.0 = Debug|Any CPU
+		{72E5E459-5045-4785-BD53-FE93EF10ECF7}.Release|x86.ActiveCfg = Release|Any CPU
+		{72E5E459-5045-4785-BD53-FE93EF10ECF7}.Release|x86.Build.0 = Release|Any CPU
+		{83F76D79-CA64-45D6-978B-AB6528F1D4F1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{83F76D79-CA64-45D6-978B-AB6528F1D4F1}.Debug|x86.Build.0 = Debug|Any CPU
+		{83F76D79-CA64-45D6-978B-AB6528F1D4F1}.Release|x86.ActiveCfg = Release|Any CPU
+		{83F76D79-CA64-45D6-978B-AB6528F1D4F1}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90} = {6A5832F9-5282-4942-AB13-0F1D4D391BB2}
 		{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F} = {6A5832F9-5282-4942-AB13-0F1D4D391BB2}
 		{72E5E459-5045-4785-BD53-FE93EF10ECF7} = {6A5832F9-5282-4942-AB13-0F1D4D391BB2}
 		{83F76D79-CA64-45D6-978B-AB6528F1D4F1} = {6A5832F9-5282-4942-AB13-0F1D4D391BB2}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2BEA84E0-80AB-46A9-BBA5-0542ABAE7140}
 	EndGlobalSection
 EndGlobal

--- a/Bootstrap/Bootstrap.cs
+++ b/Bootstrap/Bootstrap.cs
@@ -146,11 +146,11 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
 
         private static readonly List<MavenPackage> MAVEN_PACKAGES = new List<MavenPackage>()
         {
-            new MavenPackage("com.amazonaws", "amazon-kinesis-client", "1.7.2"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-dynamodb", "1.11.14"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-s3", "1.11.14"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-kms", "1.11.14"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-core", "1.11.14"),
+            new MavenPackage("com.amazonaws", "amazon-kinesis-client", "1.9.0"),
+            new MavenPackage("com.amazonaws", "aws-java-sdk-dynamodb", "1.11.273"),
+            new MavenPackage("com.amazonaws", "aws-java-sdk-s3", "1.11.273"),
+            new MavenPackage("com.amazonaws", "aws-java-sdk-kms", "1.11.273"),
+            new MavenPackage("com.amazonaws", "aws-java-sdk-core", "1.11.273"),
             new MavenPackage("org.apache.httpcomponents", "httpclient", "4.5.2"),
             new MavenPackage("org.apache.httpcomponents", "httpcore", "4.4.4"),
             new MavenPackage("commons-codec", "commons-codec", "1.9"),
@@ -159,8 +159,8 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
             new MavenPackage("com.fasterxml.jackson.core", "jackson-core", "2.6.6"),
             new MavenPackage("com.fasterxml.jackson.dataformat", "jackson-dataformat-cbor", "2.6.6"),
             new MavenPackage("joda-time", "joda-time", "2.8.1"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-kinesis", "1.11.14"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-cloudwatch", "1.11.14"),
+            new MavenPackage("com.amazonaws", "aws-java-sdk-kinesis", "1.11.273"),
+            new MavenPackage("com.amazonaws", "aws-java-sdk-cloudwatch", "1.11.273"),
             new MavenPackage("com.google.guava", "guava", "18.0"),
             new MavenPackage("com.google.protobuf", "protobuf-java", "2.6.1"),
             new MavenPackage("commons-lang", "commons-lang", "2.6"),

--- a/Bootstrap/Bootstrap.csproj
+++ b/Bootstrap/Bootstrap.csproj
@@ -1,52 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProjectGuid>{6F631BD8-5530-4E0E-B5BB-3CFC9710BB90}</ProjectGuid>
+   <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputType>Exe</OutputType>
-    <RootNamespace>Amazon.Kinesis.ClientLibrary.Bootstrap</RootNamespace>
-    <AssemblyName>Bootstrap</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Externalconsole>true</Externalconsole>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Externalconsole>true</Externalconsole>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject>Amazon.Kinesis.ClientLibrary.Bootstrap.MainClass</StartupObject>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="CommandLine">
-      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
-    </Reference>
+    <PackageReference Include="CommandLineParser" Version="2.2.1" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Bootstrap.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
+
 </Project>

--- a/Bootstrap/Properties/launchSettings.json
+++ b/Bootstrap/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "Bootstrap": {
+      "commandName": "Project",
+      "commandLineArgs": "--properties kcl.properties --execute",
+      "workingDirectory": "..\\SampleConsumer"
+    }
+  }
+}

--- a/Bootstrap/packages.config
+++ b/Bootstrap/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
-</packages>

--- a/ClientLibrary/ClientLibrary.cs
+++ b/ClientLibrary/ClientLibrary.cs
@@ -631,7 +631,7 @@ namespace Amazon.Kinesis.ClientLibrary
             }
         }
 
-        private readonly StateMachine<State, Trigger> _stateMachine = new StateMachine<State, Trigger>(State.Start);
+        private readonly StateMachine<State, Trigger> _stateMachine = new StateMachine<State, Trigger>(State.Start, FiringMode.Immediate);
        
         private readonly IRecordProcessor _processor;
         private readonly IoHandler _iohandler;

--- a/ClientLibrary/ClientLibrary.cs
+++ b/ClientLibrary/ClientLibrary.cs
@@ -50,6 +50,12 @@ namespace Amazon.Kinesis.ClientLibrary
         /// </summary>
         /// <value>The partition key.</value>
         public abstract string PartitionKey { get; }
+
+        /// <summary>
+        /// The approximate time that the record was inserted into the stream
+        /// </summary>
+        /// <value>server-side timestamp</value>
+        public abstract double ApproximateArrivalTimestamp { get; }
     }
 
     /// <summary>
@@ -470,7 +476,12 @@ namespace Amazon.Kinesis.ClientLibrary
         [DataMember(Name = "partitionKey")]
         private string _partitionKey;
 
+        [DataMember(Name = "approximateArrivalTimestamp")]
+        private double _approximateArrivalTimestamp;
+
         public override string PartitionKey { get { return _partitionKey; } }
+
+        public override double ApproximateArrivalTimestamp => _approximateArrivalTimestamp;
 
         public override byte[] Data
         {

--- a/ClientLibrary/ClientLibrary.csproj
+++ b/ClientLibrary/ClientLibrary.csproj
@@ -1,57 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProjectGuid>{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>Amazon.Kinesis.ClientLibrary</RootNamespace>
-    <AssemblyName>AmazonKinesisClientLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Externalconsole>true</Externalconsole>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Numerics" />
-    <Reference Include="System.Data.Linq" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="NSubstitute">
-      <HintPath>..\packages\NSubstitute.1.8.1.0\lib\net45\NSubstitute.dll</HintPath>
-    </Reference>
-    <Reference Include="Stateless">
-      <HintPath>..\packages\Stateless.2.5.11.0\lib\portable-net40+sl50+win+wp80\Stateless.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+    <PackageReference Include="Stateless" Version="4.1.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ClientLibrary.cs" />
-    <Compile Include="ClientLibraryTest.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
+
 </Project>

--- a/SampleConsumer/SampleConsumer.csproj
+++ b/SampleConsumer/SampleConsumer.csproj
@@ -1,45 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProjectGuid>{83F76D79-CA64-45D6-978B-AB6528F1D4F1}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>Amazon.Kinesis.ClientLibrary.SampleConsumer</RootNamespace>
-    <AssemblyName>SampleConsumer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <PlatformTarget>x86</PlatformTarget>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <PlatformTarget>x86</PlatformTarget>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+
   <ItemGroup>
-    <Compile Include="SampleConsumer.cs" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Include="kcl.properties" />
+    <ProjectReference Include="..\ClientLibrary\ClientLibrary.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\ClientLibrary\ClientLibrary.csproj">
-      <Project>{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}</Project>
-      <Name>ClientLibrary</Name>
-    </ProjectReference>
+    <None Update="kcl.properties">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
+
 </Project>

--- a/SampleConsumer/kcl.properties
+++ b/SampleConsumer/kcl.properties
@@ -1,7 +1,7 @@
 # The script that abides by the multi-language protocol. This script will
 # be executed by the MultiLangDaemon, which will communicate with this script
 # over STDIN and STDOUT according to the multi-language protocol.
-executableName = SampleConsumer.exe
+executableName = dotnet SampleConsumer.dll
 
 # The name of an Amazon Kinesis stream to process.
 streamName = myTestStream

--- a/SampleProducer/SampleProducer.cs
+++ b/SampleProducer/SampleProducer.cs
@@ -17,8 +17,6 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading;
-using Amazon;
-using Amazon.Kinesis;
 using Amazon.Kinesis.Model;
 
 /// <summary>
@@ -69,7 +67,7 @@ namespace Amazon.Kinesis.ClientLibrary.SampleProducer
                 createStreamRequest.StreamName = myStreamName;
                 createStreamRequest.ShardCount = myStreamSize;
                 var createStreamReq = createStreamRequest;
-                kinesisClient.CreateStream(createStreamReq);
+                var CreateStreamResponse = kinesisClient.CreateStreamAsync(createStreamReq).Result;
                 Console.Error.WriteLine("Created Stream : " + myStreamName);
             }
             catch (ResourceInUseException)
@@ -89,10 +87,10 @@ namespace Amazon.Kinesis.ClientLibrary.SampleProducer
                 requestRecord.StreamName = myStreamName;
                 requestRecord.Data = new MemoryStream(Encoding.UTF8.GetBytes("testData-" + j));
                 requestRecord.PartitionKey = "partitionKey-" + j;
-                PutRecordResult putResult = kinesisClient.PutRecord(requestRecord);
+                var putResultResponse = kinesisClient.PutRecordAsync(requestRecord).Result;
                 Console.Error.WriteLine(
                     String.Format("Successfully putrecord {0}:\n\t partition key = {1,15}, shard ID = {2}",
-                        j, requestRecord.PartitionKey, putResult.ShardId));
+                        j, requestRecord.PartitionKey, putResultResponse.ShardId));
             }
 
             // Uncomment the following if you wish to delete the stream here.
@@ -125,7 +123,7 @@ namespace Amazon.Kinesis.ClientLibrary.SampleProducer
             {
                 DescribeStreamRequest describeStreamReq = new DescribeStreamRequest();
                 describeStreamReq.StreamName = myStreamName;
-                DescribeStreamResult describeResult = kinesisClient.DescribeStream(describeStreamReq);
+                var describeResult = kinesisClient.DescribeStreamAsync(describeStreamReq).Result;
                 string streamStatus = describeResult.StreamDescription.StreamStatus;
                 Console.Error.WriteLine("  - current state: " + streamStatus);
                 if (streamStatus == StreamStatus.ACTIVE)

--- a/SampleProducer/SampleProducer.csproj
+++ b/SampleProducer/SampleProducer.csproj
@@ -1,50 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProjectGuid>{72E5E459-5045-4785-BD53-FE93EF10ECF7}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <RootNamespace>Amazon.Kinesis.ClientLibrary.SampleProducer</RootNamespace>
-    <AssemblyName>SampleProducer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <PlatformTarget>x86</PlatformTarget>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <PlatformTarget>x86</PlatformTarget>
-  </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+
   <ItemGroup>
-    <Compile Include="SampleProducer.cs" />
+    <PackageReference Include="AWSSDK.Kinesis" Version="3.3.5.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\ClientLibrary\ClientLibrary.csproj">
-      <Project>{6B616B6F-D58D-498D-9AE6-8625AA5A2F4F}</Project>
-      <Name>ClientLibrary</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\ClientLibrary\ClientLibrary.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <Reference Include="AWSSDK">
-      <HintPath>..\packages\AWSSDK.2.3.25.0\lib\net45\AWSSDK.dll</HintPath>
-    </Reference>
+    <None Update="kcl.properties">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
#8 

.Net core version of amazon-kinesis-client-net. I had my chances and tried to port the library to .net core but found many challenges, the biggest was the .net core version of Stateless library (https://github.com/dotnet-state-machine/stateless/issues/223). They fixed the issue and released a new version that I am using here.

TODO

1. Since now this is a cross platform library, I commented the registry part for locating java because it is 
    windows specific and later will add something that can work on different operating systems.
2. The HelpOption attribute is removed from the latest ComandLineParser library and I did not get why do you need this attribute so I removed it and everything was still working just fine. I want to investigate on how to achieve the same functionality using the new library.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
