### PR TITLE
Add support for Amazon Kinesis Client Library 2.x

### DIFF
--- a/Bootstrap/Bootstrap.cs
+++ b/Bootstrap/Bootstrap.cs
@@ -39,10 +39,7 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
         /// <value>The name of the jar file.</value>
         public String FileName
         {
-            get
-            {
-                return String.Format("{0}-{1}.jar", ArtifactId, Version);
-            }
+            get { return String.Format("{0}-{1}.jar", ArtifactId, Version); }
         }
 
         public MavenPackage(String groupId, String artifactId, String version)
@@ -71,6 +68,7 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
             {
                 Directory.CreateDirectory(folder);
             }
+
             String destination = Path.Combine(folder, FileName);
             if (!File.Exists(destination))
             {
@@ -103,7 +101,9 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
     /// </summary>
     class Options
     {
-        [Option('j', "java", Required = false, HelpText = "Path to java, used to start the KCL multi-lang daemon. Attempts to auto-detect if not specified.")]
+        [Option('j', "java", Required = false,
+            HelpText =
+                "Path to java, used to start the KCL multi-lang daemon. Attempts to auto-detect if not specified.")]
         public string JavaLocation { get; set; }
 
         [Option('p', "properties", Required = true, HelpText = "Path to properties file used to configure the KCL.")]
@@ -112,9 +112,12 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
         [Option("jar-folder", Required = false, HelpText = "Folder to place required jars in. Defaults to ./jars")]
         public string JarFolder { get; set; }
 
-        [Option('e', "execute", HelpText = "Actually launch the KCL. If not specified, prints the command used to launch the KCL.")]
+        [Option('e', "execute", HelpText =
+            "Actually launch the KCL. If not specified, prints the command used to launch the KCL.")]
         public bool ShouldExecute { get; set; }
-
+        
+        [Option('l', "log-configuration", Required = false, HelpText = "A Logback XML configuration file")]
+        public string LogbackConfiguration { get; set; }
     }
 
     internal enum OperatingSystemCategory
@@ -134,25 +137,68 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
 
         private static readonly List<MavenPackage> MAVEN_PACKAGES = new List<MavenPackage>()
         {
-            new MavenPackage("com.amazonaws", "amazon-kinesis-client", "1.9.3"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-dynamodb", "1.11.471"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-s3", "1.11.471"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-kms", "1.11.471"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-core", "1.11.471"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-kinesis", "1.11.471"),
-            new MavenPackage("com.amazonaws", "aws-java-sdk-cloudwatch", "1.11.471"),
-            new MavenPackage("org.apache.httpcomponents", "httpclient", "4.5.6"),
-            new MavenPackage("org.apache.httpcomponents", "httpcore", "4.4.10"),
-            new MavenPackage("commons-codec", "commons-codec", "1.11"),
-            new MavenPackage("com.fasterxml.jackson.core", "jackson-databind", "2.9.8"),
-            new MavenPackage("com.fasterxml.jackson.core", "jackson-annotations", "2.9.8"),
-            new MavenPackage("com.fasterxml.jackson.core", "jackson-core", "2.9.8"),
+            new MavenPackage("software.amazon.kinesis", "amazon-kinesis-client-multilang", "2.1.2"),
+            new MavenPackage("software.amazon.kinesis", "amazon-kinesis-client", "2.1.2"),
+            new MavenPackage("software.amazon.awssdk", "kinesis", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "aws-cbor-protocol", "2.4.0"),
             new MavenPackage("com.fasterxml.jackson.dataformat", "jackson-dataformat-cbor", "2.9.8"),
-            new MavenPackage("joda-time", "joda-time", "2.10.1"),
+            new MavenPackage("software.amazon.awssdk", "aws-json-protocol", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "dynamodb", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "cloudwatch", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "netty-nio-client", "2.4.0"),
+            new MavenPackage("io.netty", "netty-codec-http", "4.1.32.Final"),
+            new MavenPackage("io.netty", "netty-codec-http2", "4.1.32.Final"),
+            new MavenPackage("io.netty", "netty-codec", "4.1.32.Final"),
+            new MavenPackage("io.netty", "netty-transport", "4.1.32.Final"),
+            new MavenPackage("io.netty", "netty-resolver", "4.1.32.Final"),
+            new MavenPackage("io.netty", "netty-common", "4.1.32.Final"),
+            new MavenPackage("io.netty", "netty-buffer", "4.1.32.Final"),
+            new MavenPackage("io.netty", "netty-handler", "4.1.32.Final"),
+            new MavenPackage("io.netty", "netty-transport-native-epoll", "4.1.32.Final"),
+            new MavenPackage("io.netty", "netty-transport-native-unix-common", "4.1.32.Final"),
+            new MavenPackage("com.typesafe.netty", "netty-reactive-streams-http", "2.0.0"),
+            new MavenPackage("com.typesafe.netty", "netty-reactive-streams", "2.0.0"),
+            new MavenPackage("org.reactivestreams", "reactive-streams", "1.0.2"),
             new MavenPackage("com.google.guava", "guava", "26.0-jre"),
-            new MavenPackage("com.google.protobuf", "protobuf-java", "3.6.1"),
-            new MavenPackage("org.apache.commons", "commons-lang3", "3.7"),
-            new MavenPackage("commons-logging", "commons-logging", "1.2")
+            new MavenPackage("com.google.code.findbugs", "jsr305", "3.0.2"),
+            new MavenPackage("org.checkerframework", "checker-qual", "2.5.2"),
+            new MavenPackage("com.google.errorprone", "error_prone_annotations", "2.1.3"),
+            new MavenPackage("com.google.j2objc", "j2objc-annotations", "1.1"),
+            new MavenPackage("org.codehaus.mojo", "animal-sniffer-annotations", "1.14"),
+            new MavenPackage("com.google.protobuf", "protobuf-java", "2.6.1"),
+            new MavenPackage("org.apache.commons", "commons-lang3", "3.8.1"),
+            new MavenPackage("org.slf4j", "slf4j-api", "1.7.25"),
+            new MavenPackage("io.reactivex.rxjava2", "rxjava", "2.1.14"),
+            new MavenPackage("software.amazon.awssdk", "sts", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "aws-query-protocol", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "protocol-core", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "profiles", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "sdk-core", "2.4.0"),
+            new MavenPackage("com.fasterxml.jackson.core", "jackson-core", "2.9.8"),
+            new MavenPackage("com.fasterxml.jackson.core", "jackson-databind", "2.9.8"),
+            new MavenPackage("software.amazon.awssdk", "auth", "2.4.0"),
+            new MavenPackage("software.amazon", "flow", "1.7"),
+            new MavenPackage("software.amazon.awssdk", "http-client-spi", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "regions", "2.4.0"),
+            new MavenPackage("com.fasterxml.jackson.core", "jackson-annotations", "2.9.0"),
+            new MavenPackage("software.amazon.awssdk", "annotations", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "utils", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "aws-core", "2.4.0"),
+            new MavenPackage("software.amazon.awssdk", "apache-client", "2.4.0"),
+            new MavenPackage("org.apache.httpcomponents", "httpclient", "4.5.6"),
+            new MavenPackage("commons-codec", "commons-codec", "1.10"),
+            new MavenPackage("org.apache.httpcomponents", "httpcore", "4.4.10"),
+            new MavenPackage("com.amazonaws", "aws-java-sdk-core", "1.11.477"),
+            new MavenPackage("commons-logging", "commons-logging", "1.1.3"),
+            new MavenPackage("software.amazon.ion", "ion-java", "1.0.2"),
+            new MavenPackage("joda-time", "joda-time", "2.8.1"),
+            new MavenPackage("ch.qos.logback", "logback-classic", "1.2.3"),
+            new MavenPackage("ch.qos.logback", "logback-core", "1.2.3"),
+            new MavenPackage("com.beust", "jcommander", "1.72"),
+            new MavenPackage("commons-io", "commons-io", "2.6"),
+            new MavenPackage("org.apache.commons", "commons-collections4", "4.2"),
+            new MavenPackage("commons-beanutils", "commons-beanutils", "1.9.3"),
+            new MavenPackage("commons-collections", "commons-collections", "3.2.2")
         };
 
         /// <summary>
@@ -166,6 +212,7 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
             {
                 jarFolder = "jars";
             }
+
             if (!Path.IsPathRooted(jarFolder))
             {
                 jarFolder = Path.Combine(Directory.GetCurrentDirectory(), jarFolder);
@@ -177,6 +224,7 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
             {
                 mp.Fetch(jarFolder);
             }
+
             Console.Error.WriteLine("Done.");
 
             List<string> files = Directory.GetFiles(jarFolder).Where(f => f.EndsWith(".jar")).ToList();
@@ -191,6 +239,7 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
             {
                 java = "java";
             }
+
             Process proc = new Process
             {
                 StartInfo = new ProcessStartInfo
@@ -206,7 +255,7 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
                 proc.WaitForExit();
                 return java;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
             }
             //TODO find away to read from registery on different OSs
@@ -235,15 +284,16 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
         {
             var parserResult = Parser.Default.ParseArguments<Options>(args);
 
-            parserResult.WithParsed(options => {
-
+            parserResult.WithParsed(options =>
+            {
                 string javaClassPath = FetchJars(options.JarFolder);
 
                 string java = FindJava(options.JavaLocation);
 
                 if (java == null)
                 {
-                    Console.Error.WriteLine("java could not be found. You may need to install it, or manually specifiy the path to it.");
+                    Console.Error.WriteLine(
+                        "java could not be found. You may need to install it, or manually specify the path to it.");
 
                     Environment.Exit(2);
                 }
@@ -253,11 +303,17 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
                     java,
                     "-cp",
                     javaClassPath,
-                    "com.amazonaws.services.kinesis.multilang.MultiLangDaemon",
-                    options.PropertiesFile
+                    "software.amazon.kinesis.multilang.MultiLangDaemon",                    
+                    "-p", 
+                    options.PropertiesFile                    
                 };
-                if (options.ShouldExecute)
+                if (!string.IsNullOrEmpty(options.LogbackConfiguration))
                 {
+                    cmd.Add("-l");
+                    cmd.Add(options.LogbackConfiguration);
+                }
+                if (options.ShouldExecute)
+                {                    
                     // Start the KCL.
                     Process proc = new Process
                     {
@@ -279,6 +335,7 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
                     {
                         c = "& " + c;
                     }
+
                     Console.WriteLine(c);
                 }
             });

--- a/Bootstrap/Bootstrap.cs
+++ b/Bootstrap/Bootstrap.cs
@@ -1,17 +1,17 @@
-﻿/*
- * Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Amazon Software License (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/asl/
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
+﻿//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
 
 using System;
 using System.IO;
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using CommandLine;
 using System.Linq;
-
 
 namespace Amazon.Kinesis.ClientLibrary.Bootstrap
 {

--- a/ClientLibrary.Test/ClientLibrary.Test.csproj
+++ b/ClientLibrary.Test/ClientLibrary.Test.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="Stateless" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClientLibrary/ClientLibrary.cs
+++ b/ClientLibrary/ClientLibrary.cs
@@ -1,197 +1,28 @@
-/*
- * Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Amazon Software License (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/asl/
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
 
 using System;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using System.Linq;
-using Stateless;
 using System.Threading;
 
 namespace Amazon.Kinesis.ClientLibrary
 {
     #region Public
-
-    /// <summary>
-    /// A Kinesis record.
-    /// </summary>
-    [DataContract]
-    public abstract class Record
-    {
-        /// <summary>
-        /// Gets the binary data from this Kinesis record, already decoded from Base64.
-        /// </summary>
-        /// <value>The data in the Kinesis record.</value>
-        public abstract byte[] Data { get; }
-
-        /// <summary>
-        /// Gets the sequence number of this Kinesis record.
-        /// </summary>
-        /// <value>The sequence number.</value>
-        public abstract string SequenceNumber { get; }
-
-        /// <summary>
-        /// Gets the partition key of this Kinesis record.
-        /// </summary>
-        /// <value>The partition key.</value>
-        public abstract string PartitionKey { get; }
-
-        /// <summary>
-        /// The approximate time that the record was inserted into the stream
-        /// </summary>
-        /// <value>server-side timestamp</value>
-        public abstract double ApproximateArrivalTimestamp { get; }
-    }
-
-    /// <summary>
-    /// Used by IRecordProcessors when they want to checkpoint their progress.
-    /// The Amazon Kinesis Client Library will pass an object implementing this interface to IRecordProcessors,
-    /// so they can checkpoint their progress.
-    /// </summary>
-    public abstract class Checkpointer
-    {
-        internal abstract void Checkpoint(string sequenceNumber, CheckpointErrorHandler errorHandler = null);
-
-        /// <summary>
-        /// <para>
-        /// This method will checkpoint the progress at the last data record that was delivered to the record processor.
-        /// </para>
-        /// <para>
-        /// Upon failover (after a successful checkpoint() call), the new/replacement IRecordProcessor instance
-        /// will receive data records whose sequenceNumber > checkpoint position (for each partition key).
-        /// </para>
-        /// <para>
-        /// In steady state, applications should checkpoint periodically (e.g. once every 5 minutes).
-        /// </para>
-        /// <para>
-        /// Calling this API too frequently can slow down the application (because it puts pressure on the underlying
-        /// checkpoint storage layer).
-        /// </para>
-        /// <para>
-        /// You may optionally pass a CheckpointErrorHandler to the method, which will be invoked when the
-        /// checkpoint operation fails. 
-        /// </para>
-        /// </summary>
-        /// <param name="errorHandler">CheckpointErrorHandler that is invoked when the checkpoint operation fails.</param>
-        public void Checkpoint(CheckpointErrorHandler errorHandler = null)
-        {
-            Checkpoint(null as string, errorHandler);
-        }
-
-        /// <summary>
-        /// <para>
-        /// This method will checkpoint the progress at the sequence number of the specified record.
-        /// </para>
-        /// <para>
-        /// Upon failover (after a successful checkpoint() call), the new/replacement IRecordProcessor instance
-        /// will receive data records whose sequenceNumber > checkpoint position (for each partition key).
-        /// </para>
-        /// <para>
-        /// In steady state, applications should checkpoint periodically (e.g. once every 5 minutes).
-        /// </para>
-        /// <para>
-        /// Calling this API too frequently can slow down the application (because it puts pressure on the underlying
-        /// checkpoint storage layer).
-        /// </para>
-        /// <para>
-        /// You may optionally pass a CheckpointErrorHandler to the method, which will be invoked when the
-        /// checkpoint operation fails. 
-        /// </para>
-        /// </summary>
-        /// <param name="record">Record whose sequence number to checkpoint at.</param>
-        /// <param name="errorHandler">CheckpointErrorHandler that is invoked when the checkpoint operation fails.</param>
-        public void Checkpoint(Record record, CheckpointErrorHandler errorHandler = null)
-        {
-            Checkpoint(record.SequenceNumber, errorHandler);
-        }
-    }
-
-    /// <summary>
-    /// Contains a batch of records to be processed, along with contextual information.
-    /// </summary>
-    public interface ProcessRecordsInput
-    {
-        /// <summary>
-        /// Get the records to be processed.
-        /// </summary>
-        /// <value>The records.</value>
-        List<Record> Records { get; }
-
-        /// <summary>
-        /// Gets the checkpointer.
-        /// </summary>
-        /// <value>The checkpointer.</value>
-        Checkpointer Checkpointer { get; }
-    }
-
-    /// <summary>
-    /// Contextual information that can used to perform specialized initialization for this IRecordProcessor.
-    /// </summary>
-    public interface InitializationInput
-    {
-        /// <summary>
-        /// Gets the shard identifier.
-        /// </summary>
-        /// <value>The shard identifier. Each IRecordProcessor processes records from one and only one shard.</value>
-        string ShardId { get; }
-    }
-
-    /// <summary>
-    /// Contextual information that can used to perform specialized shutdown procedures for this IRecordProcessor.
-    /// </summary>
-    public interface ShutdownInput {
-        /// <summary>
-        /// Gets the shutdown reason.
-        /// </summary>
-        /// <value>The shutdown reason.</value>
-        ShutdownReason Reason { get; }
-
-        /// <summary>
-        /// Gets the checkpointer.
-        /// </summary>
-        /// <value>The checkpointer.</value>
-        Checkpointer Checkpointer { get; }
-    }
-
-    /// <summary>
-    /// Reason the RecordProcessor is being shutdown.
-    /// Used to distinguish between a fail-over vs. a termination (shard is closed and all records have been delivered).
-    /// In case of a fail over, applications should NOT checkpoint as part of shutdown,
-    /// since another record processor may have already started processing records for that shard.
-    /// In case of termination (resharding use case), applications SHOULD checkpoint their progress to indicate
-    /// that they have successfully processed all the records (processing of child shards can then begin).
-    /// </summary>
-    public enum ShutdownReason {
-        /// <summary>
-        /// Processing will be moved to a different record processor (fail over, load balancing use cases).
-        /// Applications SHOULD NOT checkpoint their progress (as another record processor may have already started
-        /// processing data).
-        /// </summary>
-        ZOMBIE,
-
-        /// <summary>
-        /// Terminate processing for this RecordProcessor (resharding use case).
-        /// Indicates that the shard is closed and all records from the shard have been delivered to the application.
-        /// Applications SHOULD checkpoint their progress to indicate that they have successfully processed all records
-        /// from this shard and processing of child shards can be started.
-        /// </summary>
-        TERMINATE
-    }
 
     /// <summary>
     /// Instances of this delegate can be passed to Checkpointer's Checkpoint methods. The delegate will be
@@ -228,67 +59,6 @@ namespace Amazon.Kinesis.ClientLibrary
     }
 
     /// <summary>
-    /// Receives and processes Kinesis records. Each IRecordProcessor instance processes data from 1 and only 1 shard.
-    /// </summary>
-    public interface IRecordProcessor
-    {
-        /// <summary>
-        /// Invoked by the Amazon Kinesis Client Library before data records are delivered to the IRecordProcessor
-        /// instance (via processRecords).
-        /// </summary>
-        /// <param name="input">
-        /// The InitializationInput containing information such as the shard id being assigned to this IRecordProcessor.
-        /// </param>
-        void Initialize(InitializationInput input);
-
-        /// <summary>
-        /// <para>
-        /// Process data records. The Amazon Kinesis Client Library will invoke this method to deliver data records to the
-        /// application.
-        /// </para>
-        /// <para>
-        /// Upon fail over, the new instance will get records with sequence number > checkpoint position
-        /// for each partition key.
-        /// </para>
-        /// </summary>
-        /// <param name="input">
-        /// ProcessRecordsInput that contains a batch of records, a Checkpointer, as well as relevant contextual information.
-        /// </param> 
-        void ProcessRecords(ProcessRecordsInput input);
-
-        /// <summary>
-        /// <para>
-        /// Invoked by the Amazon Kinesis Client Library to indicate it will no longer send data records to this
-        /// RecordProcessor instance.
-        /// </para>
-        /// <para>
-        /// The reason parameter indicates:
-        /// <list type="bullet">
-        /// <item>
-        /// <term>TERMINATE</term>
-        /// <description>
-        /// The shard has been closed and there will not be any more records to process. The
-        /// record processor should checkpoint (after doing any housekeeping) to acknowledge that it has successfully
-        /// completed processing all records in this shard.
-        /// </description>>
-        /// </item>
-        /// <item>
-        /// <term>ZOMBIE</term>
-        /// <description>
-        /// A fail over has occurred and a different record processor is (or will be) responsible
-        /// for processing records.
-        /// </description>
-        /// </item>
-        /// </list>
-        /// </para>
-        /// </summary>
-        /// <param name="input">
-        /// ShutdownInput that contains the reason, a Checkpointer, as well as contextual information.
-        /// </param>
-        void Shutdown(ShutdownInput input);
-    }
-
-    /// <summary>
     /// Instances of KclProcess communicate with the multi-lang daemon. The Main method of your application must
     /// create an instance of KclProcess and call its Run method.
     /// </summary>
@@ -303,7 +73,17 @@ namespace Amazon.Kinesis.ClientLibrary
             return Create(recordProcessor, new IoHandler());
         }
 
+        public static KclProcess Create(IShardRecordProcessor recordProcessor)
+        {
+            return Create(recordProcessor, new IoHandler());
+        }
+
         internal static KclProcess Create(IRecordProcessor recordProcessor, IoHandler ioHandler)
+        {
+            return new DefaultKclProcess(new ShardRecordProcessorToRecordProcessor(recordProcessor), ioHandler);
+        }
+
+        internal static KclProcess Create(IShardRecordProcessor recordProcessor, IoHandler ioHandler)
         {
             return new DefaultKclProcess(recordProcessor, ioHandler);
         }
@@ -317,6 +97,43 @@ namespace Amazon.Kinesis.ClientLibrary
     }
 
     #endregion
+
+    internal class ShardRecordProcessorToRecordProcessor : IShardRecordProcessor
+    {
+        private IRecordProcessor RecordProcessor { get; set; }
+
+        internal ShardRecordProcessorToRecordProcessor(IRecordProcessor recordProcessor)
+        {
+            RecordProcessor = recordProcessor;
+        }
+
+        public void Initialize(InitializationInput input)
+        {
+            RecordProcessor.Initialize(input);
+        }
+
+        public void ProcessRecords(ProcessRecordsInput input)
+        {
+            RecordProcessor.ProcessRecords(input);
+        }
+
+        public void LeaseLost(LeaseLossInput leaseLossInput)
+        {
+            RecordProcessor.Shutdown(new DefaultShutdownInput(ShutdownReason.ZOMBIE, null));
+        }
+
+        public void ShardEnded(ShardEndedInput shardEndedInput)
+        {
+            RecordProcessor.Shutdown(new DefaultShutdownInput(ShutdownReason.TERMINATE, shardEndedInput.Checkpointer));
+        }
+
+        public void ShutdownRequested(ShutdownRequestedInput shutdownRequestedInput)
+        {
+            //
+            // Does nothing
+            //
+        }
+    }
 
     internal class MalformedActionException : Exception
     {
@@ -332,218 +149,117 @@ namespace Amazon.Kinesis.ClientLibrary
     }
 
     [DataContract]
-    internal class Action
-    {
-        protected static readonly Dictionary<String, Type> Types = new Dictionary<String, Type>()
-        {
-            { "initialize", typeof(InitializeAction) },
-            { "processRecords", typeof(ProcessRecordsAction) },
-            { "shutdown", typeof(ShutdownAction) },
-            { "checkpoint", typeof(CheckpointAction) },
-            { "status", typeof(StatusAction) }
-        };
-
-        public static Action Parse(string json)
-        {
-            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(json)))
-            {
-                try
-                {
-                    // Deserialize just the action field to get the type
-                    var jsonSerializer = new DataContractJsonSerializer(typeof(Action));
-                    var a = jsonSerializer.ReadObject(ms) as Action;
-                    // Deserialize again into the appropriate type
-                    ms.Position = 0;
-                    jsonSerializer = new DataContractJsonSerializer(Types[a.Type]);
-                    a = jsonSerializer.ReadObject(ms) as Action;
-                    return a;
-                }
-                catch (Exception e)
-                {
-                    ms.Position = 0;
-                    throw new MalformedActionException("Received an action which couldn't be understood: " + json, e);
-                }
-            }
-        }
-
-        [DataMember(Name = "action")]
-        public string Type { get; set; }
-
-        public override string ToString()
-        {
-            var jsonSerializer = new DataContractJsonSerializer(GetType());
-            var ms = new MemoryStream();
-            jsonSerializer.WriteObject(ms, this);
-            ms.Position = 0;
-            using (StreamReader sr = new StreamReader(ms))
-            {
-                return sr.ReadLine();
-            }
-        }
-    }
-
-    [DataContract]
-    internal class InitializeAction : Action
-    {
-        [DataMember(Name = "shardId")]
-        public string ShardId { get; set; }
-
-        public InitializeAction(string shardId)
-        {
-            Type = "initialize";
-            ShardId = shardId;
-        }
-    }
-
-    [DataContract]
-    internal class ProcessRecordsAction : Action
-    {
-        [DataMember(Name = "records")]
-        private List<DefaultRecord> _actualRecords;
-
-        public List<Record> Records
-        {
-            get
-            {
-                return _actualRecords.Select(x => x as Record).ToList();
-            }
-        }
-
-        public ProcessRecordsAction(params DefaultRecord[] records)
-        {
-            Type = "processRecords";
-            _actualRecords = records.ToArray().ToList();
-        }
-    }
-
-    [DataContract]
-    internal class ShutdownAction : Action
-    {
-        [DataMember(Name = "reason")]
-        public string Reason { get; set; }
-
-        public ShutdownAction(string reason)
-        {
-            Type = "shutdown";
-            Reason = reason;
-        }
-    }
-
-    [DataContract]
-    internal class CheckpointAction : Action
-    {
-        [DataMember(Name = "sequenceNumber")]
-        public string SequenceNumber { get; set; }
-
-        [DataMember(Name = "error", IsRequired = false)]
-        public string Error { get; set; }
-
-        public CheckpointAction(string sequenceNumber)
-        {
-            Type = "checkpoint";
-            SequenceNumber = sequenceNumber;
-        }
-    }
-
-    [DataContract]
-    internal class StatusAction : Action
-    {
-        [DataMember(Name = "responseFor")]
-        public string ResponseFor { get; set; }
-
-        public StatusAction(Type t)
-            : this(Types.Where(x => x.Value == t).Select(x => x.Key).First())
-        {
-        }
-
-        public StatusAction(string type)
-        {
-            Type = "status";
-            ResponseFor = type;
-        }
-    }
-
-    [DataContract]
     internal class DefaultRecord : Record
     {
-        [DataMember(Name = "sequenceNumber")]
-        private string _sequenceNumber;
+        [DataMember(Name = "sequenceNumber")] private string _sequenceNumber;
 
-        [DataMember(Name = "data")]
-        private string _base64;
+        [DataMember(Name = "subSequenceNumber")]
+        private long? _subSequenceNumber;
+
+        [DataMember(Name = "data")] private string _base64;
         private byte[] _data;
 
-        [DataMember(Name = "partitionKey")]
-        private string _partitionKey;
+        [DataMember(Name = "partitionKey")] private string _partitionKey;
 
         [DataMember(Name = "approximateArrivalTimestamp")]
         private double _approximateArrivalTimestamp;
 
-        public override string PartitionKey { get { return _partitionKey; } }
+        public override string PartitionKey => _partitionKey;
 
         public override double ApproximateArrivalTimestamp => _approximateArrivalTimestamp;
+
+        public override string SequenceNumber => _sequenceNumber;
+        public override long? SubSequenceNumber => _subSequenceNumber;
 
         public override byte[] Data
         {
             get
             {
-                if (_data == null)
+                if (_data != null)
                 {
-                    _data = Convert.FromBase64String(_base64);
-                    _base64 = null;
+                    return _data;
                 }
+
+                _data = Convert.FromBase64String(_base64);
+                _base64 = null;
                 return _data;
             }
         }
 
-        public override string SequenceNumber { get { return _sequenceNumber; } }
-
-        public DefaultRecord(string sequenceNumber, string partitionKey, string data)
+        public DefaultRecord(string sequenceNumber, string partitionKey, string data, long? subSequenceNumber = null,
+            double approximateArrivalTimestamp = 0d)
         {
             _data = Encoding.UTF8.GetBytes(data);
             _sequenceNumber = sequenceNumber;
             _partitionKey = partitionKey;
+            _subSequenceNumber = subSequenceNumber;
+            _approximateArrivalTimestamp = approximateArrivalTimestamp;
         }
     }
 
     internal class DefaultProcessRecordsInput : ProcessRecordsInput
     {
-        private readonly List<Record> _records;
-        private readonly Checkpointer _checkpointer;
+        public List<Record> Records { get; }
 
-        public List<Record> Records { get { return _records; } }
-        public Checkpointer Checkpointer { get { return _checkpointer; } }
+        public Checkpointer Checkpointer { get; }
 
-        public DefaultProcessRecordsInput(List<Record> records, Checkpointer checkpointer) {
-            _records = records;
-            _checkpointer = checkpointer;
+        public long? MillisBehindLatest { get; }
+
+        public DefaultProcessRecordsInput(ProcessRecordsAction processRecordsAction, Checkpointer checkpointer)
+        {
+            Records = processRecordsAction.Records;
+            MillisBehindLatest = processRecordsAction.MillisBehindLatest;
+            Checkpointer = checkpointer;
         }
     }
 
     internal class DefaultInitializationInput : InitializationInput
     {
-        private readonly string _shardId;
+        public string ShardId { get; }
+        public string SequenceNumber { get; }
+        public long? SubSequenceNumber { get; }
 
-        public string ShardId { get { return _shardId; } }
-
-        public DefaultInitializationInput(string shardId)
+        public DefaultInitializationInput(InitializeAction initializeAction)
         {
-            _shardId = shardId;
+            ShardId = initializeAction.ShardId;
+            SequenceNumber = initializeAction.SequenceNumber;
+            SubSequenceNumber = initializeAction.SubSequenceNumber;
         }
     }
 
     internal class DefaultShutdownInput : ShutdownInput
     {
-        private readonly ShutdownReason _reason;
-        private readonly Checkpointer _checkpointer;
-
-        public ShutdownReason Reason { get { return _reason; } }
-        public Checkpointer Checkpointer { get { return _checkpointer; } }
+        public ShutdownReason Reason { get; }
+        public Checkpointer Checkpointer { get; }
 
         public DefaultShutdownInput(ShutdownReason reason, Checkpointer checkpointer)
         {
-            _reason = reason;
-            _checkpointer = checkpointer;
+            Reason = reason;
+            Checkpointer = checkpointer;
+        }
+    }
+
+    internal class DefaultLeaseLostInput : LeaseLossInput
+    {
+    }
+
+    internal class DefaultShardEndedInput : ShardEndedInput
+    {
+        public Checkpointer Checkpointer { get; }
+
+        public DefaultShardEndedInput(Checkpointer checkpointer)
+        {
+            Checkpointer = checkpointer;
+        }
+    }
+
+    internal class DefaultShutdownRequestedInput : ShutdownRequestedInput
+    {
+        public Checkpointer Checkpointer { get; }
+
+        public DefaultShutdownRequestedInput(Checkpointer checkpointer)
+        {
+            Checkpointer = checkpointer;
         }
     }
 
@@ -567,18 +283,14 @@ namespace Amazon.Kinesis.ClientLibrary
 
         public void WriteAction(Action a)
         {
-            _outWriter.WriteLine(a.ToString());
+            _outWriter.WriteLine(a.ToJson());
             _outWriter.Flush();
         }
 
         public Action ReadAction()
         {
-            string s = _reader.ReadLine();
-            if (s == null)
-            {
-                return null;
-            }
-            return Action.Parse(s);
+            var s = _reader.ReadLine();
+            return s == null ? null : Action.Parse(s);
         }
 
         public void WriteError(string message, Exception e)
@@ -598,72 +310,42 @@ namespace Amazon.Kinesis.ClientLibrary
 
     internal class DefaultKclProcess : KclProcess
     {
-        private enum State
-        {
-            Start,
-            Ready,
-            Checkpointing,
-            FinalCheckpointing,
-            ShuttingDown,
-            End,
-            Processing,
-            Initializing
-        }
-
-        private enum Trigger
-        {
-            BeginCheckpoint,
-            BeginInitialize,
-            BeginProcessRecords,
-            BeginShutdown,
-            FinishCheckpoint,
-            FinishInitialize,
-            FinishProcessRecords,
-            FinishShutdown
-        }
-
         private class InternalCheckpointer : Checkpointer
         {
-            private readonly DefaultKclProcess _p;
+            private readonly DefaultKclProcess _kclProcess;
 
-            public InternalCheckpointer(DefaultKclProcess p)
+            public InternalCheckpointer(DefaultKclProcess kclProcess)
             {
-                _p = p;
+                _kclProcess = kclProcess;
             }
 
             internal override void Checkpoint(string sequenceNumber, CheckpointErrorHandler errorHandler = null)
             {
-                _p.CheckpointSeqNo = sequenceNumber;
-                _p._stateMachine.Fire(Trigger.BeginCheckpoint);
-                if (_p.CheckpointError != null && errorHandler != null)
+                _kclProcess._iohandler.WriteAction(new CheckpointAction(sequenceNumber));
+                var response = _kclProcess._iohandler.ReadAction();
+                if (response is CheckpointAction checkpointResponse)
                 {
-                    errorHandler.Invoke(sequenceNumber, _p.CheckpointError, this);
+                    if (!string.IsNullOrEmpty(checkpointResponse.Error))
+                    {
+                        errorHandler?.Invoke(sequenceNumber, checkpointResponse.Error, this);
+                    }
+                }
+                else
+                {
+                    errorHandler?.Invoke(sequenceNumber, $"Unexpected response type {response.GetType().Name}", this);
                 }
             }
         }
 
-        private readonly StateMachine<State, Trigger> _stateMachine = new StateMachine<State, Trigger>(State.Start, FiringMode.Immediate);
-       
-        private readonly IRecordProcessor _processor;
+        private readonly IShardRecordProcessor _processor;
         private readonly IoHandler _iohandler;
         private readonly Checkpointer _checkpointer;
 
-        private string CheckpointSeqNo { get; set; }
-
-        private string CheckpointError { get; set; }
-
-        private string ShardId { get; set; }
-
-        private ShutdownReason ShutdownReason { get; set; }
-
-        private List<Record> Records { get; set; }
-
-        internal DefaultKclProcess(IRecordProcessor processor, IoHandler iohandler)
+        internal DefaultKclProcess(IShardRecordProcessor processor, IoHandler iohandler)
         {
             _processor = processor;
             _iohandler = iohandler;
             _checkpointer = new InternalCheckpointer(this);
-            ConfigureStateMachine();
         }
 
         public override void Run()
@@ -687,133 +369,10 @@ namespace Amazon.Kinesis.ClientLibrary
             }
         }
 
-        private void DispatchAction(Action a)
+        private void DispatchAction(Action action)
         {
-            var initAction = a as InitializeAction;
-            if (initAction != null)
-            {
-                ShardId = initAction.ShardId;
-                _stateMachine.Fire(Trigger.BeginInitialize);
-                return;
-            }
-
-            var processRecordAction = a as ProcessRecordsAction;
-            if (processRecordAction != null)
-            {
-                Records = processRecordAction.Records;
-                _stateMachine.Fire(Trigger.BeginProcessRecords);
-                return;
-            }
-
-            var shutdownAction = a as ShutdownAction;
-            if (shutdownAction != null)
-            {
-                ShutdownReason = (ShutdownReason) Enum.Parse(typeof(ShutdownReason), shutdownAction.Reason);
-                _stateMachine.Fire(Trigger.BeginShutdown);
-                return;
-            }
-
-            var checkpointAction = a as CheckpointAction;
-            if (checkpointAction != null)
-            {
-                CheckpointError = checkpointAction.Error;
-                CheckpointSeqNo = checkpointAction.SequenceNumber;
-                _stateMachine.Fire(Trigger.FinishCheckpoint);
-                return;
-            }
-
-            throw new MalformedActionException("Received an action which couldn't be understood: " + a.Type);       
-        }
-
-        private void ConfigureStateMachine()
-        {
-            _stateMachine.OnUnhandledTrigger((state, trigger) =>
-                {
-                    throw new MalformedActionException("trigger " + trigger + " is invalid for state " + state);
-                });
-
-            // Uncomment to help debugging
-            // _stateMachine.OnTransitioned(t => Console.Error.WriteLine(t.Source + " --> " + t.Destination));
-
-            _stateMachine.Configure(State.Start)
-                .Permit(Trigger.BeginInitialize, State.Initializing);
-
-            _stateMachine.Configure(State.Ready)
-                .OnEntryFrom(Trigger.FinishProcessRecords, FinishProcessRecords)
-                .OnEntryFrom(Trigger.FinishInitialize, FinishInitialize)
-                .Permit(Trigger.BeginProcessRecords, State.Processing)
-                .Permit(Trigger.BeginShutdown, State.ShuttingDown);
-
-            _stateMachine.Configure(State.Checkpointing)
-                .OnEntryFrom(Trigger.BeginCheckpoint, BeginCheckpoint)
-                .Permit(Trigger.FinishCheckpoint, State.Processing);
-
-            _stateMachine.Configure(State.FinalCheckpointing)
-                .OnEntryFrom(Trigger.BeginCheckpoint, BeginCheckpoint)
-                .Permit(Trigger.FinishCheckpoint, State.ShuttingDown);
-
-            _stateMachine.Configure(State.ShuttingDown)
-                .OnEntryFrom(Trigger.BeginShutdown, BeginShutdown)
-                .OnEntryFrom(Trigger.FinishCheckpoint, FinishCheckpoint)
-                .Permit(Trigger.FinishShutdown, State.End)
-                .Permit(Trigger.BeginCheckpoint, State.FinalCheckpointing);
-
-            _stateMachine.Configure(State.End)
-                .OnEntryFrom(Trigger.FinishShutdown, FinishShutdown);
-
-            _stateMachine.Configure(State.Processing)
-                .OnEntryFrom(Trigger.BeginProcessRecords, BeginProcessRecords)
-                .OnEntryFrom(Trigger.FinishCheckpoint, FinishCheckpoint)
-                .Permit(Trigger.BeginCheckpoint, State.Checkpointing)
-                .Permit(Trigger.FinishProcessRecords, State.Ready);
-
-            _stateMachine.Configure(State.Initializing)
-                .OnEntryFrom(Trigger.BeginInitialize, BeginInitialize)
-                .Permit(Trigger.FinishInitialize, State.Ready);
-        }
-
-        private void BeginInitialize()
-        {
-            _processor.Initialize(new DefaultInitializationInput(ShardId));
-            _stateMachine.Fire(Trigger.FinishInitialize);
-        }
-
-        private void FinishInitialize()
-        {
-            _iohandler.WriteAction(new StatusAction(typeof(InitializeAction)));
-        }
-
-        private void BeginShutdown()
-        {
-            _processor.Shutdown(new DefaultShutdownInput(ShutdownReason, _checkpointer));
-            _stateMachine.Fire(Trigger.FinishShutdown);
-        }
-
-        private void FinishShutdown()
-        {
-            _iohandler.WriteAction(new StatusAction(typeof(ShutdownAction)));
-        }
-
-        private void BeginProcessRecords()
-        {
-            _processor.ProcessRecords(new DefaultProcessRecordsInput(Records, _checkpointer));
-            _stateMachine.Fire(Trigger.FinishProcessRecords);
-        }
-
-        private void FinishProcessRecords()
-        {
-            _iohandler.WriteAction(new StatusAction(typeof(ProcessRecordsAction)));
-        }
-
-        private void BeginCheckpoint()
-        {
-            _iohandler.WriteAction(new CheckpointAction(CheckpointSeqNo));
-            ProcessNextLine();
-        }
-
-        private void FinishCheckpoint()
-        {
-            // nothing to do here
+            action.Dispatch(_processor, _checkpointer);
+            _iohandler.WriteAction(new StatusAction(action.GetType()));
         }
     }
 }

--- a/ClientLibrary/ClientLibrary.csproj
+++ b/ClientLibrary/ClientLibrary.csproj
@@ -1,12 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Stateless" Version="4.1.0" />
-  </ItemGroup>
 
 </Project>

--- a/ClientLibrary/IRecordProcessor.cs
+++ b/ClientLibrary/IRecordProcessor.cs
@@ -1,0 +1,78 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    /// <summary>
+    /// Receives and processes Kinesis records. Each IRecordProcessor instance processes data from 1 and only 1 shard.
+    /// </summary>
+    public interface IRecordProcessor
+    {
+        /// <summary>
+        /// Invoked by the Amazon Kinesis Client Library before data records are delivered to the IRecordProcessor
+        /// instance (via processRecords).
+        /// </summary>
+        /// <param name="input">
+        /// The InitializationInput containing information such as the shard id being assigned to this IRecordProcessor.
+        /// </param>
+        void Initialize(InitializationInput input);
+
+        /// <summary>
+        /// <para>
+        /// Process data records. The Amazon Kinesis Client Library will invoke this method to deliver data records to the
+        /// application.
+        /// </para>
+        /// <para>
+        /// Upon fail over, the new instance will get records with sequence number > checkpoint position
+        /// for each partition key.
+        /// </para>
+        /// </summary>
+        /// <param name="input">
+        /// ProcessRecordsInput that contains a batch of records, a Checkpointer, as well as relevant contextual information.
+        /// </param> 
+        void ProcessRecords(ProcessRecordsInput input);
+
+        /// <summary>
+        /// <para>
+        /// Invoked by the Amazon Kinesis Client Library to indicate it will no longer send data records to this
+        /// RecordProcessor instance.
+        /// </para>
+        /// <para>
+        /// The reason parameter indicates:
+        /// <list type="bullet">
+        /// <item>
+        /// <term>TERMINATE</term>
+        /// <description>
+        /// The shard has been closed and there will not be any more records to process. The
+        /// record processor should checkpoint (after doing any housekeeping) to acknowledge that it has successfully
+        /// completed processing all records in this shard.
+        /// </description>>
+        /// </item>
+        /// <item>
+        /// <term>ZOMBIE</term>
+        /// <description>
+        /// A fail over has occurred and a different record processor is (or will be) responsible
+        /// for processing records.
+        /// </description>
+        /// </item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        /// <param name="input">
+        /// ShutdownInput that contains the reason, a Checkpointer, as well as contextual information.
+        /// </param>
+        void Shutdown(ShutdownInput input);
+    }
+}

--- a/ClientLibrary/IShardRecordProcessor.cs
+++ b/ClientLibrary/IShardRecordProcessor.cs
@@ -1,0 +1,78 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    public interface IShardRecordProcessor
+    {
+        /// <summary>
+        ///     Invoked by the Amazon Kinesis Client Library before data records are delivered to the IRecordProcessor
+        ///     instance (via processRecords).
+        /// </summary>
+        /// <param name="input">
+        ///     The InitializationInput containing information such as the shard id being assigned to this IRecordProcessor.
+        /// </param>
+        void Initialize(InitializationInput input);
+
+        /// <summary>
+        ///     <para>
+        ///         Process data records. The Amazon Kinesis Client Library will invoke this method to deliver data records to the
+        ///         application.
+        ///     </para>
+        ///     <para>
+        ///         Upon fail over, the new instance will get records with sequence number > checkpoint position
+        ///         for each partition key.
+        ///     </para>
+        /// </summary>
+        /// <param name="input">
+        ///     ProcessRecordsInput that contains a batch of records, a Checkpointer, as well as relevant contextual information.
+        /// </param>
+        void ProcessRecords(ProcessRecordsInput input);
+
+        /// <summary>
+        ///     This is invoked when the record processor no longer holds the lease and must shut down.
+        /// </summary>
+        /// <remarks>
+        ///     <para>The record processor should do any necessary cleanup and prepare to exit.</para>
+        ///     <para>*Any attempts to checkpoint will fail after a record processor has lost its lease.*</para>
+        /// </remarks>
+        /// <param name="leaseLossInput">Information related to the lease loss</param>
+        void LeaseLost(LeaseLossInput leaseLossInput);
+
+        /// <summary>
+        ///     This is invoked when the record processor has reached the end of the shard, and will no longer receive additional
+        ///     records.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         Scaling shards in Amazon Kinesis Data Streams will close shards to indicate that they have been
+        ///         replaced by the scaled shards.  A closed shard can no longer receive records from PutRecord or PutRecords,
+        ///         and therefore when the end of the shard is reached can no longer
+        ///     </para>
+        /// </remarks>
+        /// <param name="shardEndedInput">Information related to the end </param>
+        void ShardEnded(ShardEndedInput shardEndedInput);
+
+        /// <summary>
+        ///     Invoked when the parent process has been requested to shutdown.
+        /// </summary>
+        /// <remarks>
+        ///     This provides a final chance to checkpoint while the record processor still holds
+        /// </remarks>
+        /// <param name="shutdownRequestedInput"></param>
+        void ShutdownRequested(ShutdownRequestedInput shutdownRequestedInput);
+
+    }
+}

--- a/ClientLibrary/inputs/Checkpointer.cs
+++ b/ClientLibrary/inputs/Checkpointer.cs
@@ -1,0 +1,79 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+namespace Amazon.Kinesis.ClientLibrary
+{
+    /// <summary>
+    /// Used by IRecordProcessors when they want to checkpoint their progress.
+    /// The Amazon Kinesis Client Library will pass an object implementing this interface to IRecordProcessors,
+    /// so they can checkpoint their progress.
+    /// </summary>
+    public abstract class Checkpointer
+    {
+        internal abstract void Checkpoint(string sequenceNumber, CheckpointErrorHandler errorHandler = null);
+
+        /// <summary>
+        /// <para>
+        /// This method will checkpoint the progress at the last data record that was delivered to the record processor.
+        /// </para>
+        /// <para>
+        /// Upon failover (after a successful checkpoint() call), the new/replacement IRecordProcessor instance
+        /// will receive data records whose sequenceNumber > checkpoint position (for each partition key).
+        /// </para>
+        /// <para>
+        /// In steady state, applications should checkpoint periodically (e.g. once every 5 minutes).
+        /// </para>
+        /// <para>
+        /// Calling this API too frequently can slow down the application (because it puts pressure on the underlying
+        /// checkpoint storage layer).
+        /// </para>
+        /// <para>
+        /// You may optionally pass a CheckpointErrorHandler to the method, which will be invoked when the
+        /// checkpoint operation fails. 
+        /// </para>
+        /// </summary>
+        /// <param name="errorHandler">CheckpointErrorHandler that is invoked when the checkpoint operation fails.</param>
+        public void Checkpoint(CheckpointErrorHandler errorHandler = null)
+        {
+            Checkpoint(null as string, errorHandler);
+        }
+
+        /// <summary>
+        /// <para>
+        /// This method will checkpoint the progress at the sequence number of the specified record.
+        /// </para>
+        /// <para>
+        /// Upon failover (after a successful checkpoint() call), the new/replacement IRecordProcessor instance
+        /// will receive data records whose sequenceNumber > checkpoint position (for each partition key).
+        /// </para>
+        /// <para>
+        /// In steady state, applications should checkpoint periodically (e.g. once every 5 minutes).
+        /// </para>
+        /// <para>
+        /// Calling this API too frequently can slow down the application (because it puts pressure on the underlying
+        /// checkpoint storage layer).
+        /// </para>
+        /// <para>
+        /// You may optionally pass a CheckpointErrorHandler to the method, which will be invoked when the
+        /// checkpoint operation fails. 
+        /// </para>
+        /// </summary>
+        /// <param name="record">Record whose sequence number to checkpoint at.</param>
+        /// <param name="errorHandler">CheckpointErrorHandler that is invoked when the checkpoint operation fails.</param>
+        public void Checkpoint(Record record, CheckpointErrorHandler errorHandler = null)
+        {
+            Checkpoint(record.SequenceNumber, errorHandler);
+        }
+    }
+}

--- a/ClientLibrary/inputs/InitializationInput.cs
+++ b/ClientLibrary/inputs/InitializationInput.cs
@@ -1,0 +1,40 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+namespace Amazon.Kinesis.ClientLibrary
+{
+    /// <summary>
+    /// Contextual information that can used to perform specialized initialization for this IRecordProcessor.
+    /// </summary>
+    public interface InitializationInput
+    {
+        /// <summary>
+        /// Gets the shard identifier.
+        /// </summary>
+        /// <value>The shard identifier. Each IRecordProcessor processes records from one and only one shard.</value>
+        string ShardId { get; }
+
+        /// <summary>
+        /// The sequence number that this shard was last checkpointed at. This maybe null if the shard has never been
+        /// checkpointed.
+        /// </summary>
+        string SequenceNumber { get; }
+
+        /// <summary>
+        /// The subsequence number that the shard was last checkpoint at.  This may be null if the shard has never been
+        /// checkpointed or was not checkpointed on a deaggregated record.
+        /// </summary>
+        long? SubSequenceNumber { get; }
+    }
+}

--- a/ClientLibrary/inputs/LeaseLossInput.cs
+++ b/ClientLibrary/inputs/LeaseLossInput.cs
@@ -1,0 +1,24 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+namespace Amazon.Kinesis.ClientLibrary
+{
+    /// <summary>
+    /// Indicates that this record processor has lost its lease and will be shutdown.
+    /// </summary>
+    public interface LeaseLossInput
+    {
+        
+    }
+}

--- a/ClientLibrary/inputs/ProcessRecordsInput.cs
+++ b/ClientLibrary/inputs/ProcessRecordsInput.cs
@@ -1,0 +1,41 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+using System.Collections.Generic;
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    /// <summary>
+    /// Contains a batch of records to be processed, along with contextual information.
+    /// </summary>
+    public interface ProcessRecordsInput
+    {
+        /// <summary>
+        /// Get the records to be processed.
+        /// </summary>
+        /// <value>The records.</value>
+        List<Record> Records { get; }
+
+        /// <summary>
+        /// Gets the checkpointer.
+        /// </summary>
+        /// <value>The checkpointer.</value>
+        Checkpointer Checkpointer { get; }
+        
+        /// <summary>
+        /// Indicates how far behind the current time this entry is in milliseconds
+        /// </summary>
+        long? MillisBehindLatest { get; }
+    }
+}

--- a/ClientLibrary/inputs/Record.cs
+++ b/ClientLibrary/inputs/Record.cs
@@ -1,0 +1,56 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+using System.Runtime.Serialization;
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    /// <summary>
+    /// A Kinesis record.
+    /// </summary>
+    [DataContract]
+    public abstract class Record
+    {
+        /// <summary>
+        /// Gets the binary data from this Kinesis record, already decoded from Base64.
+        /// </summary>
+        /// <value>The data in the Kinesis record.</value>
+        public abstract byte[] Data { get; }
+
+        /// <summary>
+        /// Gets the sequence number of this Kinesis record.
+        /// </summary>
+        /// <value>The sequence number.</value>
+        public abstract string SequenceNumber { get; }
+
+        /// <summary>
+        /// Get the subsequence number of this Kinesis record.  This is only set if the record is part of an aggregate
+        /// record
+        /// </summary>
+        /// <value>The subsequence number.</value>
+        public abstract long? SubSequenceNumber { get; }
+
+        /// <summary>
+        /// Gets the partition key of this Kinesis record.
+        /// </summary>
+        /// <value>The partition key.</value>
+        public abstract string PartitionKey { get; }
+
+        /// <summary>
+        /// The approximate time that the record was inserted into the stream
+        /// </summary>
+        /// <value>server-side timestamp</value>
+        public abstract double ApproximateArrivalTimestamp { get; }
+    }
+}

--- a/ClientLibrary/inputs/ShardEndedInput.cs
+++ b/ClientLibrary/inputs/ShardEndedInput.cs
@@ -1,0 +1,28 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+namespace Amazon.Kinesis.ClientLibrary
+{
+    /// <summary>
+    ///     Indicates that the record processor has reached the end of the shard and now needs to checkpoint to complete the
+    ///     shard.
+    /// </summary>
+    public interface ShardEndedInput
+    {
+        /// <summary>
+        /// The Checkpointer that must be used to complete processing
+        /// </summary>
+        Checkpointer Checkpointer { get; }
+    }
+}

--- a/ClientLibrary/inputs/ShutdownInput.cs
+++ b/ClientLibrary/inputs/ShutdownInput.cs
@@ -1,0 +1,33 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+namespace Amazon.Kinesis.ClientLibrary
+{
+    /// <summary>
+    /// Contextual information that can used to perform specialized shutdown procedures for this IRecordProcessor.
+    /// </summary>
+    public interface ShutdownInput {
+        /// <summary>
+        /// Gets the shutdown reason.
+        /// </summary>
+        /// <value>The shutdown reason.</value>
+        ShutdownReason Reason { get; }
+
+        /// <summary>
+        /// Gets the checkpointer.
+        /// </summary>
+        /// <value>The checkpointer.</value>
+        Checkpointer Checkpointer { get; }
+    }
+}

--- a/ClientLibrary/inputs/ShutdownReason.cs
+++ b/ClientLibrary/inputs/ShutdownReason.cs
@@ -1,0 +1,41 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+namespace Amazon.Kinesis.ClientLibrary
+{
+    /// <summary>
+    /// Reason the RecordProcessor is being shutdown.
+    /// Used to distinguish between a fail-over vs. a termination (shard is closed and all records have been delivered).
+    /// In case of a fail over, applications should NOT checkpoint as part of shutdown,
+    /// since another record processor may have already started processing records for that shard.
+    /// In case of termination (resharding use case), applications SHOULD checkpoint their progress to indicate
+    /// that they have successfully processed all the records (processing of child shards can then begin).
+    /// </summary>
+    public enum ShutdownReason {
+        /// <summary>
+        /// Processing will be moved to a different record processor (fail over, load balancing use cases).
+        /// Applications SHOULD NOT checkpoint their progress (as another record processor may have already started
+        /// processing data).
+        /// </summary>
+        ZOMBIE,
+
+        /// <summary>
+        /// Terminate processing for this RecordProcessor (resharding use case).
+        /// Indicates that the shard is closed and all records from the shard have been delivered to the application.
+        /// Applications SHOULD checkpoint their progress to indicate that they have successfully processed all records
+        /// from this shard and processing of child shards can be started.
+        /// </summary>
+        TERMINATE
+    }
+}

--- a/ClientLibrary/inputs/ShutdownRequestedInput.cs
+++ b/ClientLibrary/inputs/ShutdownRequestedInput.cs
@@ -1,0 +1,21 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+namespace Amazon.Kinesis.ClientLibrary
+{
+    public interface ShutdownRequestedInput
+    {
+        Checkpointer Checkpointer { get; }
+    }
+}

--- a/ClientLibrary/messages/Action.cs
+++ b/ClientLibrary/messages/Action.cs
@@ -1,0 +1,87 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    [DataContract]
+    internal class Action
+    {
+        protected static readonly Dictionary<string, Type> Types = new Dictionary<string, Type>()
+        {
+            { InitializeAction.ACTION, typeof(InitializeAction) },
+            { ProcessRecordsAction.ACTION, typeof(ProcessRecordsAction) },
+            { LeaseLostAction.ACTION, typeof(LeaseLostAction) },
+            { ShardEndedAction.ACTION, typeof(ShardEndedAction) },
+            { ShutdownRequestedAction.ACTION, typeof(ShutdownRequestedAction) },
+            { CheckpointAction.ACTION, typeof(CheckpointAction) },
+            { StatusAction.ACTION, typeof(StatusAction) }
+        };
+
+        public static Action Parse(string json)
+        {
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            {
+                try
+                {
+                    // Deserialize just the action field to get the type
+                    var jsonSerializer = new DataContractJsonSerializer(typeof(Action));
+                    var a = jsonSerializer.ReadObject(ms) as Action;
+                    // Deserialize again into the appropriate type
+                    ms.Position = 0;
+                    jsonSerializer = new DataContractJsonSerializer(Types[a.Type]);
+                    a = jsonSerializer.ReadObject(ms) as Action;
+                    return a;
+                }
+                catch (Exception e)
+                {
+                    ms.Position = 0;
+                    throw new MalformedActionException("Received an action which couldn't be understood: " + json, e);
+                }
+            }
+        }
+
+        [DataMember(Name = "action")]
+        public string Type { get; set; }
+
+        public virtual void Dispatch(IShardRecordProcessor processor, Checkpointer checkpointer)
+        {
+            throw new NotImplementedException("Actions need to implement Dispatch, this likely indicates a bug.");
+        }
+
+        public string ToJson()
+        {
+            var jsonSerializer = new DataContractJsonSerializer(GetType());
+            var ms = new MemoryStream();
+            jsonSerializer.WriteObject(ms, this);
+            ms.Position = 0;
+            using (var sr = new StreamReader(ms))
+            {
+                return sr.ReadLine();
+            }
+        }
+
+        public override string ToString()
+        {
+            return ToJson();
+        }
+    }
+}

--- a/ClientLibrary/messages/CheckpointAction.cs
+++ b/ClientLibrary/messages/CheckpointAction.cs
@@ -1,0 +1,44 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    [DataContract]
+    internal class CheckpointAction : Action
+    {
+
+        public const string ACTION = "checkpoint";
+        
+        [DataMember(Name = "sequenceNumber")]
+        public string SequenceNumber { get; set; }
+
+        [DataMember(Name = "error", IsRequired = false)]
+        public string Error { get; set; }
+
+        public CheckpointAction(string sequenceNumber)
+        {
+            Type = ACTION;
+            SequenceNumber = sequenceNumber;
+        }
+
+        public override void Dispatch(IShardRecordProcessor processor, Checkpointer checkpointer)
+        {
+            throw new  NotSupportedException("CheckpointAction should never be dispatched, but handled in line");
+        }
+    }
+}

--- a/ClientLibrary/messages/InitializeAction.cs
+++ b/ClientLibrary/messages/InitializeAction.cs
@@ -1,0 +1,42 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+using System.Runtime.Serialization;
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    [DataContract]
+    internal class InitializeAction : Action
+    {
+        public const string ACTION = "initialize";
+
+        [DataMember(Name = "shardId")]
+        public string ShardId { get; set; }
+        [DataMember(Name = "sequenceNumber")]
+        public string SequenceNumber { get; set; }
+        [DataMember(Name = "subSequenceNumber")]
+        public long? SubSequenceNumber { get; set; }
+
+        public InitializeAction(string shardId)
+        {
+            Type = ACTION;
+            ShardId = shardId;
+        }
+
+        public override void Dispatch(IShardRecordProcessor processor, Checkpointer checkpointer)
+        {
+            processor.Initialize(new DefaultInitializationInput(this));
+        }
+    }
+}

--- a/ClientLibrary/messages/LeaseLostAction.cs
+++ b/ClientLibrary/messages/LeaseLostAction.cs
@@ -1,0 +1,34 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+using System.Runtime.Serialization;
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    [DataContract]
+    internal class LeaseLostAction : Action
+    {
+        public const string ACTION = "leaseLost";
+
+        public LeaseLostAction()
+        {
+            Type = ACTION;
+        }
+        
+        public override void Dispatch(IShardRecordProcessor processor, Checkpointer checkpointer)
+        {
+            processor.LeaseLost(new DefaultLeaseLostInput());
+        }
+    }
+}

--- a/ClientLibrary/messages/ProcessRecordsAction.cs
+++ b/ClientLibrary/messages/ProcessRecordsAction.cs
@@ -1,0 +1,52 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    [DataContract]
+    internal class ProcessRecordsAction : Action
+    {
+
+        public const string ACTION = "processRecords";
+        
+        [DataMember(Name = "records")]
+        private List<DefaultRecord> _actualRecords;
+
+        [DataMember(Name = "millisBehindLatest")]
+        public long? MillisBehindLatest { get; set; }
+
+        public List<Record> Records
+        {
+            get
+            {
+                return _actualRecords.Select(x => x as Record).ToList();
+            }
+        }
+
+        public ProcessRecordsAction(params DefaultRecord[] records)
+        {
+            Type = ACTION;
+            _actualRecords = records.ToList();
+        }
+
+        public override void Dispatch(IShardRecordProcessor processor, Checkpointer checkpointer)
+        {
+            processor.ProcessRecords(new DefaultProcessRecordsInput(this, checkpointer));
+        }
+    }
+}

--- a/ClientLibrary/messages/ShardEndedAction.cs
+++ b/ClientLibrary/messages/ShardEndedAction.cs
@@ -1,0 +1,35 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+using System.Runtime.Serialization;
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    [DataContract]
+    internal class ShardEndedAction : Action
+    {
+
+        public const string ACTION = "shardEnded";
+
+        public ShardEndedAction()
+        {
+            Type = ACTION;
+        }
+        
+        public override void Dispatch(IShardRecordProcessor processor, Checkpointer checkpointer)
+        {
+            processor.ShardEnded(new DefaultShardEndedInput(checkpointer));
+        }
+    }
+}

--- a/ClientLibrary/messages/ShutdownRequestedAction.cs
+++ b/ClientLibrary/messages/ShutdownRequestedAction.cs
@@ -1,0 +1,34 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+using System.Runtime.Serialization;
+
+namespace Amazon.Kinesis.ClientLibrary
+{   
+    [DataContract]
+    internal class ShutdownRequestedAction : Action
+    {
+        public const string ACTION = "shutdownRequested";
+
+        public ShutdownRequestedAction()
+        {
+            Type = ACTION;
+        }
+        
+        public override void Dispatch(IShardRecordProcessor processor, Checkpointer checkpointer)
+        {
+            processor.ShutdownRequested(new DefaultShutdownRequestedInput(checkpointer));
+        }
+    }
+}

--- a/ClientLibrary/messages/StatusAction.cs
+++ b/ClientLibrary/messages/StatusAction.cs
@@ -1,0 +1,40 @@
+//
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Amazon Software License (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//  http://aws.amazon.com/asl/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+using System;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace Amazon.Kinesis.ClientLibrary
+{
+    [DataContract]
+    internal class StatusAction : Action
+    {
+        public const string ACTION = "status";
+        
+        [DataMember(Name = "responseFor")]
+        public string ResponseFor { get; set; }
+
+        public StatusAction(Type t)
+            : this(Types.Where(x => x.Value == t).Select(x => x.Key).First())
+        {
+        }
+
+        public StatusAction(string type)
+        {
+            Type = ACTION;
+            ResponseFor = type;
+        }
+    }
+}

--- a/SampleConsumer/kcl.properties
+++ b/SampleConsumer/kcl.properties
@@ -4,7 +4,7 @@
 executableName = dotnet SampleConsumer.dll
 
 # The name of an Amazon Kinesis stream to process.
-streamName = myTestStream
+streamName = words
 
 # Used by the KCL as the name of this application. Will be used as the name
 # of an Amazon DynamoDB table which will store the lease and checkpoint
@@ -23,13 +23,13 @@ processingLanguage = C#
 
 # Valid options at TRIM_HORIZON or LATEST.
 # See http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#API_GetShardIterator_RequestSyntax
-initialPositionInStream = TRIM_HORIZON
+initialPositionInStream = LATEST
 
 # The following properties are also available for configuring the KCL Worker that is created
 # by the MultiLangDaemon.
 
 # The KCL defaults to us-east-1
-#regionName = us-west-1
+regionName = us-west-2
 
 # Fail over time in milliseconds. A worker which does not renew it's lease within this time interval
 # will be regarded as having problems and it's shards will be assigned to other workers.
@@ -45,10 +45,10 @@ initialPositionInStream = TRIM_HORIZON
 #shardSyncIntervalMillis = 60000
 
 # Max records to fetch from Kinesis in a single GetRecords call.
-maxRecords = 5000
+# maxRecords = 5000
 
 # Idle time between record reads in milliseconds.
-idleTimeBetweenReadsInMillis = 1000
+# idleTimeBetweenReadsInMillis = 1000
 
 # Enables applications flush/checkpoint (if they have some data "in progress", but don't get new data for while)
 #callProcessRecordsEvenForEmptyRecordList = false

--- a/SampleConsumer/kcl.properties
+++ b/SampleConsumer/kcl.properties
@@ -4,7 +4,7 @@
 executableName = dotnet SampleConsumer.dll
 
 # The name of an Amazon Kinesis stream to process.
-streamName = words
+streamName = myTestStream
 
 # Used by the KCL as the name of this application. Will be used as the name
 # of an Amazon DynamoDB table which will store the lease and checkpoint
@@ -23,13 +23,13 @@ processingLanguage = C#
 
 # Valid options at TRIM_HORIZON or LATEST.
 # See http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetShardIterator.html#API_GetShardIterator_RequestSyntax
-initialPositionInStream = LATEST
+initialPositionInStream = TRIM_HORIZON
 
 # The following properties are also available for configuring the KCL Worker that is created
 # by the MultiLangDaemon.
 
 # The KCL defaults to us-east-1
-regionName = us-west-2
+regionName = us-east-1
 
 # Fail over time in milliseconds. A worker which does not renew it's lease within this time interval
 # will be regarded as having problems and it's shards will be assigned to other workers.


### PR DESCRIPTION
Removed the use of a state machine for message handling

Removed the state machine that was used for message handling and went
to a simpler dispatch model.

Classes and interfaces have been moved from a single large file to
individual files.

Added a new interface IShardRecordProcessor that replaces shutdown
with specific methods: leaseLost, and shardEnded.

Added options to the Bootstrap project for configuring logback in the
Java KCL.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
