### PR TITLE
Revbump jackson-databind and com.google.protobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ all languages.
 
 ## Release Notes
 
+### Release 3.0.1 (October 6, 2023)
+* Bumps com.google.protobuf:protobuf-java from 3.21.5 to 3.21.7 and Bumps jackson-databind from 2.13.4 to 2.13.4.2.
+
 ### Release 3.0.0 (January 12, 2023)
 * Upgraded to use version 2.4.4 of the [Amazon Kinesis Client library][amazon-kcl-github]
 

--- a/README.md
+++ b/README.md
@@ -150,9 +150,6 @@ all languages.
 
 ## Release Notes
 
-### Release 3.0.1 (October 6, 2023)
-* Bumps com.google.protobuf:protobuf-java from 3.21.5 to 3.21.7 and Bumps jackson-databind from 2.13.4 to 2.13.4.2.
-
 ### Release 3.0.0 (January 12, 2023)
 * Upgraded to use version 2.4.4 of the [Amazon Kinesis Client library][amazon-kcl-github]
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <aws-java-sdk.version>1.12.370</aws-java-sdk.version>
         <netty.version>4.1.86.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
-        <fasterxml-jackson.version>2.13.4.2</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
         <logback.version>1.3.0</logback.version>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <aws-java-sdk.version>1.12.370</aws-java-sdk.version>
         <netty.version>4.1.86.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
-        <fasterxml-jackson.version>2.13.4</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.13.4.2</fasterxml-jackson.version>
         <logback.version>1.3.0</logback.version>
     </properties>
     <dependencies>
@@ -233,7 +233,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.21.5</version>
+            <version>3.21.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Bumps com.google.protobuf:protobuf-java from 3.21.5 to 3.21.7 and Bumps jackson-databind from 2.13.4 to 2.13.4.2.

[Jackson-databind](https://github.com/awslabs/amazon-kinesis-client-net/security/dependabot/7)
[CVE-2022-3171](https://github.com/advisories/GHSA-h4h5-3hr4-j3g2)

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
