### PR TITLE
Revbump guava to 32.1.1 and netty to 4.1.100.Final, fix sdk link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ all languages.
 [DefaultAWSCredentialsProviderChain]: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html
 [kinesis-forum]: http://developer.amazonwebservices.com/connect/forum.jspa?forumID=169
 [master-zip]: https://github.com/awslabs/amazon-kinesis-client-net/archive/master.zip
-[aws-sdk-dotnet]: http://aws.amazon.com/developers/getting-started/net/
+[aws-sdk-dotnet]: https://aws.amazon.com/sdk-for-net/
 [aws-sdk-dotnet-credentials]: http://docs.aws.amazon.com/AWSSdkDocsNET/latest/DeveloperGuide/net-dg-config-creds.html#net-dg-config-creds-creds-file
 [aws-console]: http://aws.amazon.com/console/
 [sample-properties]: https://github.com/awslabs/amazon-kinesis-client-net/blob/master/SampleConsumer/kcl.properties

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <properties>
         <awssdk.version>2.19.2</awssdk.version>
         <aws-java-sdk.version>1.12.370</aws-java-sdk.version>
-        <netty.version>4.1.86.Final</netty.version>
+        <netty.version>4.1.100.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
         <logback.version>1.3.0</logback.version>
@@ -203,7 +203,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
+            <version>32.1.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Bump io.netty:netty-codec-http2 from 4.1.86.Final to 4.1.100.Final
Bump com.google.guava:guava from 31.0.1-jre to 32.1.1-jre


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
