### PR TITLE
Update ion-java to 1.11.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,9 +297,9 @@
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>software.amazon.ion</groupId>
+            <groupId>com.amazon.ion</groupId>
             <artifactId>ion-java</artifactId>
-            <version>1.5.1</version>
+            <version>1.11.4</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.glue</groupId>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Upgrade ion-java to remove security vulnerability https://github.com/awslabs/amazon-kinesis-client-net/security/dependabot/16

groupId is updated per README instructions https://github.com/amazon-ion/ion-java

> Originally ion-java was published using the group id software.amazon.ion. Since 1.4.0 the official groupId was changed to com.amazon.ion to be consistent with other Amazon open source libraries. We still maintain the legacy group id but strongly encourage users to migrate to the official one.`



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
