### PR TITLE
Revise breaking change language on release 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,11 @@ all languages.
 
 ## Release Notes
 
+### Release 3.1.1 (March 25, 2025)
+* Downgrade logback from 1.5.16 to 1.3.15 to maintain JDK 8 compatability
+
 ### Release 3.1.0 (March 12, 2025) IMPORTANT: See section ``Migration to .NET KCL 3.1.0`` to ensure upgrading does not break compatibility
+#### :warning: [BREAKING CHANGES] - Release 3.1.0 contains a dependency version that is not compatible with JDK 8. Please upgrade to a later version if your KCL application requires JDK 8.
 * [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
   * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
   * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,8 @@
         <netty.version>4.1.118.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
-        <logback.version>1.5.16</logback.version>
+        <!--do not upgrade to logback version 1.5.x, as this is not compatible with JDK 8 -->
+        <logback.version>1.3.15</logback.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Description of changes:

Downgrade logback from 1.5.16 to 1.3.15 to maintain JDK 8 compatability


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
