### PR TITLE
Upgrade the Kinesis client Dotnet code to Dotnet 8

### DIFF
--- a/Bootstrap/Bootstrap.cs
+++ b/Bootstrap/Bootstrap.cs
@@ -20,20 +20,20 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
     /// </summary>
     internal class MavenPackage
     {
-        public readonly String GroupId;
-        public readonly String ArtifactId;
-        public readonly String Version;
+        public readonly string GroupId;
+        public readonly string ArtifactId;
+        public readonly string Version;
 
         /// <summary>
         /// Gets the name of the jar file of this Maven package.
         /// </summary>
         /// <value>The name of the jar file.</value>
-        public String FileName
+        public string FileName
         {
-            get { return String.Format("{0}-{1}.jar", ArtifactId, Version); }
+            get { return string.Format("{0}-{1}.jar", ArtifactId, Version); }
         }
 
-        public MavenPackage(String groupId, String artifactId, String version)
+        public MavenPackage(string groupId, string artifactId, string version)
         {
             GroupId = groupId;
             ArtifactId = artifactId;
@@ -44,7 +44,7 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
         /// Check if the jar file for this Maven package already exists on disk.
         /// </summary>
         /// <param name="folder">Folder to look in.</param>
-        public bool Exists(String folder)
+        public bool Exists(string folder)
         {
             return File.Exists(Path.Combine(folder, FileName));
         }
@@ -53,14 +53,14 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
         /// Download the jar file for this Maven package.
         /// </summary>
         /// <param name="folder">Folder to download the file into.</param>
-        public void Fetch(String folder)
+        public void Fetch(string folder)
         {
             if (!Directory.Exists(folder))
             {
                 Directory.CreateDirectory(folder);
             }
 
-            String destination = Path.Combine(folder, FileName);
+            string destination = Path.Combine(folder, FileName);
             if (!File.Exists(destination))
             {
                 var client = new WebClient();
@@ -74,16 +74,16 @@ namespace Amazon.Kinesis.ClientLibrary.Bootstrap
         /// Gets the URL to the jar file for this Maven package.
         /// </summary>
         /// <value>The URL.</value>
-        private String Url
+        private string Url
         {
             get
             {
-                List<String> urlParts = new List<String>();
+                List<string> urlParts = new List<string>();
                 urlParts.AddRange(GroupId.Split('.'));
                 urlParts.Add(ArtifactId);
                 urlParts.Add(Version);
                 urlParts.Add(FileName);
-                return "https://search.maven.org/remotecontent?filepath=" + String.Join("/", urlParts);
+                return "https://search.maven.org/remotecontent?filepath=" + string.Join("/", urlParts);
             }
         }
     }

--- a/Bootstrap/Bootstrap.csproj
+++ b/Bootstrap/Bootstrap.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ClientLibrary.Test/ClientLibrary.Test.csproj
+++ b/ClientLibrary.Test/ClientLibrary.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/ClientLibrary.Test/ClientLibraryTest.cs
+++ b/ClientLibrary.Test/ClientLibraryTest.cs
@@ -312,7 +312,7 @@ namespace Amazon.Kinesis.ClientLibrary
             KclProcess.Create(recordProcessor, _ioHandler).Run();
             List<Action> outputActions = ParseActionsFromOutput();
 
-            Console.Error.WriteLine(String.Join("\n", outputActions.Select(x => x.ToJson()).ToList()));
+            Console.Error.WriteLine(string.Join("\n", outputActions.Select(x => x.ToJson()).ToList()));
 
             int i = 0;
             dynamic a = outputActions[i++];

--- a/ClientLibrary.Test/packages.config
+++ b/ClientLibrary.Test/packages.config
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MSTest.TestAdapter" version="3.1.1" targetFramework="net472" />
-  <package id="MSTest.TestFramework" version="3.1.1" targetFramework="net472" />
-</packages>

--- a/ClientLibrary/ClientLibrary.csproj
+++ b/ClientLibrary/ClientLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/ClientLibrary/packages.config
+++ b/ClientLibrary/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Stateless" version="5.13.0" targetFramework="net45" />
-</packages>

--- a/SampleConsumer/SampleConsumer.cs
+++ b/SampleConsumer/SampleConsumer.cs
@@ -86,7 +86,7 @@ namespace Amazon.Kinesis.ClientLibrary.SampleConsumer
 
                         // Uncomment the following if you wish to see the retrieved record data.
                         //Console.Error.WriteLine(
-                        //    String.Format("Retrieved record:\n\tpartition key = {0},\n\tsequence number = {1},\n\tdata = {2}",
+                        //    string.Format("Retrieved record:\n\tpartition key = {0},\n\tsequence number = {1},\n\tdata = {2}",
                         //    rec.PartitionKey, rec.SequenceNumber, data));
 
                         // Your own logic to process a record goes here.

--- a/SampleConsumer/SampleConsumer.csproj
+++ b/SampleConsumer/SampleConsumer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SampleProducer/SampleProducer.cs
+++ b/SampleProducer/SampleProducer.cs
@@ -86,7 +86,7 @@ namespace Amazon.Kinesis.ClientLibrary.SampleProducer
                 requestRecord.PartitionKey = "partitionKey-" + j;
                 var putResultResponse = kinesisClient.PutRecordAsync(requestRecord).Result;
                 Console.Error.WriteLine(
-                    String.Format("Successfully putrecord {0}:\n\t partition key = {1,15}, shard ID = {2}",
+                    string.Format("Successfully putrecord {0}:\n\t partition key = {1,15}, shard ID = {2}",
                         j, requestRecord.PartitionKey, putResultResponse.ShardId));
             }
 

--- a/SampleProducer/SampleProducer.csproj
+++ b/SampleProducer/SampleProducer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SampleProducer/packages.config
+++ b/SampleProducer/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AWSSDK" version="2.3.55.2" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-client-net/issues/258

*Description of changes:*
Upgrade all csproj files to target `net8.0`
Delete unused package.config files
Fix IDE warning that `String` usage can be simplified.

Checked that the tests pass still and have tested the changes work when running locally. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
