### PR TITLE
Upgrade KCL, AWS SDK, Netty, fasterxml-jackson, and Apache commons-lang3

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ namespace Sample
 For more information about [Amazon Kinesis][amazon-kinesis] and the client libraries, see the
 [official documentation][amazon-kinesis-docs] as well as the [Amazon Kinesis forums][kinesis-forum].
 
+## 🚨Important: Migration to .NET KCL 3.1.0 or later with MultiLangDaemon - Credential Provider Changes Required
+Java KCL version 2.7.0 and later uses AWS SDK for Java 2.x instead of AWS SDK for Java 1.x. For the KCL .NET 3.x versions,
+v3.1.0 is the first .NET release to use Java KCL 2.7.0. All MultiLangDaemon users upgrading from earlier versions must update
+their credential provider configuration in the `.properties` file to use credentials provider name for AWS SDK for Java 2.x.
+Failure to do this will cause your multilang KCL application to fail during startup with credential provider construction errors.
+Please check the following link for the credentials provider mapping and MultiLangDaemon credentials provider configuration guide
+
+- [AWS SDK for Java 1.x to 2.x Credentials Provider Mapping](aws.amazon.com/sdk-for-java/latest/developer-guide/migration-client-credentials.html#credentials-changes-mapping)
+- [KCL Multilang Credentials Provider Configuration Guide](https://github.com/aws/amazon-kinesis-client/blob/master/docs/multilang/configuring-credential-providers.md)
+
 ## Getting started
 
 
@@ -150,6 +160,13 @@ all languages.
 
 ## Release Notes
 
+### Release 3.1.0 (March 12, 2025) IMPORTANT: See section ``Migration to .NET KCL 3.1.0`` to ensure upgrading does not break compatibility
+* [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
+  * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
+  * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.
+* [#254](https://github.com/awslabs/amazon-kinesis-client-net/pull/254) Upgrade logback.version from 1.3.14 to 1.5.16
+* [#254](https://github.com/awslabs/amazon-kinesis-client-net/pull/254) Upgrade netty.version from 4.1.108.Final to 4.1.118.Final
+
 ### Release 3.0.2 (January 22, 2025)
 * Upgraded amazon-kinesis-client from 2.5.8 to 2.6.1 - [Java 2.6.1 release notes](https://github.com/awslabs/amazon-kinesis-client/releases/tag/v2.6.1)
 
@@ -184,7 +201,7 @@ all languages.
 * Upgraded to use version 2.4.4 of the [Amazon Kinesis Client library][amazon-kcl-github]
 
 ### Release 2.0.0 (February 27, 2019)
-* Added support for [Enhanced Fan-Out](https://aws.amazon.com/blogs/aws/kds-enhanced-fanout/).  
+* Added support for [Enhanced Fan-Out](https://aws.amazon.com/blogs/aws/kds-enhanced-fanout/).
   Enhanced Fan-Out provides dedicated throughput per stream consumer, and uses an HTTP/2 push API (SubscribeToShard) to deliver records with lower latency.
 * Updated the Amazon Kinesis Client Library for Java to version 2.1.2.
   * Version 2.1.2 uses 4 additional Kinesis API's  
@@ -201,7 +218,7 @@ all languages.
     `LeaseLost` replaces `Shutdown` where `ShutdownInput.Reason` was `ShutdownReason.ZOMBIE`.
   * Added the `ShardEnded` method which is invoked when all records from a split or merge have been processed.  
     `ShardEnded`  replaces `Shutdown` where `ShutdownInput.Reason` was `ShutdownReason.TERMINATE`.
-  * Added `ShutdownRequested` which provides the record processor a last chance to checkpoint during the Amazon Kinesis Client Library shutdown process before the lease is canceled.  
+  * Added `ShutdownRequested` which provides the record processor a last chance to checkpoint during the Amazon Kinesis Client Library shutdown process before the lease is canceled.
     * To control how long the Amazon Kinesis Client Library waits for the record processors to complete shutdown, add `timeoutInSeconds=<seconds to wait>` to your properties file.
 * Updated the AWS Java SDK version to 2.4.0
 * MultiLangDaemon now provides logging using Logback.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,11 @@ all languages.
 
 ## Release Notes
 
+### Release 3.1.1 (March 25, 2025)
+* Downgrade logback from 1.5.16 to 1.3.15 to maintain JDK 8 compatability
+
 ### Release 3.1.0 (March 12, 2025) IMPORTANT: See section ``Migration to .NET KCL 3.1.0`` to ensure upgrading does not break compatibility
+#### :warning: [BREAKING CHANGES] - Release 3.1.0 contains a dependency version that is not compatible with JDK 8. Please upgrade to a later version if your KCL application requires JDK 8.
 * [#1444](https://github.com/awslabs/amazon-kinesis-client/pull/1444) Fully remove dependency on the AWS SDK for Java 1.x which will reach [end-of-support by December 31st, 2025](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/).
   * The Glue Schema Registry integration functionality no longer depends on AWS SDK for Java 1.x. Previously, it required this as a transient dependency.
   * Multilangdaemon has been upgraded to use AWS SDK for Java 2.x. It no longer depends on AWS SDK for Java 1.x.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ all languages.
 
 ## Release Notes
 
+### Release 3.0.2 (January 22, 2025)
+* Upgraded amazon-kinesis-client from 2.5.8 to 2.6.1 - [Java 2.6.1 release notes](https://github.com/awslabs/amazon-kinesis-client/releases/tag/v2.6.1)
+
 ### Release 3.0.1 (April 24, 2024)
 * Upgraded amazon-kinesis-client from 2.4.4 to 2.5.8
 * Upgraded netcoreapp from 5.0 to 6.0

--- a/SampleConsumer/kcl.properties
+++ b/SampleConsumer/kcl.properties
@@ -12,10 +12,12 @@ streamName = kclnetsample
 applicationName = DotNetKinesisSample
 
 # Users can change the credentials provider the KCL will use to retrieve credentials.
-# The DefaultAWSCredentialsProviderChain checks several other providers, which is
+# Expected key name (case-sensitive):
+# AwsCredentialsProvider / AwsCredentialsProviderDynamoDB / AwsCredentialsProviderCloudWatch
+# The DefaultCredentialsProvider checks several other providers, which is
 # described here:
-# http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html
-AWSCredentialsProvider = DefaultAWSCredentialsProviderChain
+# https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html
+AwsCredentialsProvider = DefaultCredentialsProvider
 
 # Appended to the user agent of the KCL. Does not impact the functionality of the
 # KCL in any other way.

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,10 @@
         <awssdk.version>2.25.64</awssdk.version>
         <aws-java-sdk.version>1.12.668</aws-java-sdk.version>
         <kcl.version>2.6.1</kcl.version>
-        <netty.version>4.1.108.Final</netty.version>
+        <netty.version>4.1.118.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
-        <logback.version>1.3.14</logback.version>
+        <logback.version>1.5.16</logback.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <properties>
         <awssdk.version>2.25.64</awssdk.version>
         <aws-java-sdk.version>1.12.668</aws-java-sdk.version>
-        <kcl.version>2.6.1</kcl.version>
+        <kcl.version>2.7.0</kcl.version>
         <netty.version>4.1.118.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <awssdk.version>2.25.64</awssdk.version>
+        <awssdk.version>2.33.0</awssdk.version>
         <aws-java-sdk.version>1.12.668</aws-java-sdk.version>
-        <kcl.version>2.7.0</kcl.version>
-        <netty.version>4.1.118.Final</netty.version>
+        <kcl.version>2.7.2</kcl.version>
+        <netty.version>4.2.4.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
-        <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
+        <fasterxml-jackson.version>2.15.0</fasterxml-jackson.version>
         <!--do not upgrade to logback version 1.5.x, as this is not compatible with JDK 8 -->
         <logback.version>1.3.15</logback.version>
     </properties>
@@ -173,6 +173,16 @@
             <version>${awssdk.version}</version>
         </dependency>
         <dependency>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>retries-spi</artifactId>
+          <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>retries</artifactId>
+          <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
             <version>${netty.version}</version>
@@ -185,6 +195,11 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-base</artifactId>
             <version>${netty.version}</version>
         </dependency>
         <dependency>
@@ -275,7 +290,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.14.0</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,8 @@
         <netty.version>4.1.118.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
         <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
-        <logback.version>1.5.16</logback.version>
+        <!--do not upgrade to logback version 1.5.x, as this is not compatible with JDK 8 -->
+        <logback.version>1.3.15</logback.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <kcl.version>2.5.8</kcl.version>
-        <awssdk.version>2.19.16</awssdk.version>
-        <aws-java-sdk.version>1.12.468</aws-java-sdk.version>
+        <awssdk.version>2.25.64</awssdk.version>
+        <aws-java-sdk.version>1.12.668</aws-java-sdk.version>
+        <kcl.version>2.6.1</kcl.version>
         <netty.version>4.1.108.Final</netty.version>
         <netty-reactive.version>2.0.6</netty-reactive.version>
-        <fasterxml-jackson.version>2.14.2</fasterxml-jackson.version>
-        <logback.version>1.3.12</logback.version>
+        <fasterxml-jackson.version>2.13.5</fasterxml-jackson.version>
+        <logback.version>1.3.14</logback.version>
     </properties>
     <dependencies>
         <dependency>
@@ -137,6 +137,41 @@
             <version>${awssdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>arns</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-spi</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-auth-aws</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>checksums-spi</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>checksums</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>identity-spi</artifactId>
+            <version>${awssdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
             <version>${netty.version}</version>
@@ -219,7 +254,7 @@
         <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
-            <version>2.19.1</version>
+            <version>2.7.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.j2objc</groupId>
@@ -234,22 +269,22 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.23.0</version>
+            <version>4.27.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.5</version>
+            <version>2.0.13</version>
         </dependency>
         <dependency>
             <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
-            <version>3.1.5</version>
+            <version>3.1.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -297,6 +332,11 @@
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.amazon.ion</groupId>
             <artifactId>ion-java</artifactId>
             <version>1.11.4</version>
@@ -304,7 +344,7 @@
         <dependency>
             <groupId>software.amazon.glue</groupId>
             <artifactId>schema-registry-serde</artifactId>
-            <version>1.1.13</version>
+            <version>1.1.19</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -329,12 +369,12 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.11.0</version>
+            <version>2.16.1</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
+            <version>1.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -352,4 +392,4 @@
             <version>3.2.2</version>
         </dependency>
     </dependencies>
-</project> 
+</project>


### PR DESCRIPTION
- **Upgraded amazon-kinesis-client from 2.5.8 to 2.6.1**
- **Upgraded netty and logback versions**
- **Upgraded amazon-kinesis-client from 2.6.1 to 2.7.0**
- **Revise breaking change language on release 3.1.0**
- **Upgrade KCL, AWS SDK, Netty, fasterxml-jackson, and Apache commons-lang3**
